### PR TITLE
#26 - Add copyleft headers and files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Eduardo Pignatelli

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,3 +1,5 @@
+Copyright 2023 The Helx Authors.
+
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
@@ -14,5 +16,3 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-
-

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,18 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2023] Eduardo Pignatelli
+   Copyright [2023] The Helx Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2023] Eduardo Pignatelli
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache epignatelli/helx
+Copyright 2023 Eduardo Pignatelli
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache epignatelli/helx
-Copyright 2023 Eduardo Pignatelli
+Copyright 2023 The Helx Authors.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/examples/dqn_bsuite_catch.py
+++ b/examples/dqn_bsuite_catch.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import bsuite
 import flax.linen as nn
 import optax

--- a/examples/ppo_minihack_keyroom.py
+++ b/examples/ppo_minihack_keyroom.py
@@ -1,1 +1,16 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # TODO(epignatelli): implement PPO

--- a/examples/sac_mujoco_halfcheetah.py
+++ b/examples/sac_mujoco_halfcheetah.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import gymnasium
 import optax
 from absl import app, flags, logging

--- a/examples/sacd_procgen_coinrun.py
+++ b/examples/sacd_procgen_coinrun.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import flax.linen as nn
 import gym
 import optax

--- a/helx/__init__.py
+++ b/helx/__init__.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 __version__ = "0.2.0"
 
 from . import (

--- a/helx/agents/__init__.py
+++ b/helx/agents/__init__.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from .agent import Agent
 from .dqn import DQN, DQNHparams
 from .sac import SAC, SACHparams

--- a/helx/agents/agent.py
+++ b/helx/agents/agent.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Base classes for a Reinforcement Learning agent."""
 from __future__ import annotations
 

--- a/helx/agents/dqn.py
+++ b/helx/agents/dqn.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from typing import Any, List, Tuple

--- a/helx/agents/interop.py
+++ b/helx/agents/interop.py
@@ -1,1 +1,16 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # TODO(epignatelli): implement

--- a/helx/agents/random.py
+++ b/helx/agents/random.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from typing import Any, Tuple

--- a/helx/agents/sac.py
+++ b/helx/agents/sac.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # pyright: reportPrivateImportUsage=false
 from __future__ import annotations
 

--- a/helx/agents/sacd.py
+++ b/helx/agents/sacd.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # pyright: reportPrivateImportUsage=false
 from __future__ import annotations
 

--- a/helx/environment/__init__.py
+++ b/helx/environment/__init__.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from .bsuite import FromBsuiteEnv
 from .dm_env import FromDmEnv
 from .gym import FromGymEnv

--- a/helx/environment/base.py
+++ b/helx/environment/base.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """A set of functions to interoperate between the most common
 RL environment interfaces, like `gym`, `gymnasium`, `dm_env`, `bsuite and others."""
 from __future__ import annotations

--- a/helx/environment/bsuite.py
+++ b/helx/environment/bsuite.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import bsuite.environments

--- a/helx/environment/distributed.py
+++ b/helx/environment/distributed.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 import multiprocessing as mp
 from copy import deepcopy
@@ -161,6 +176,7 @@ class MultiprocessEnv(Environment):
         assert (
             len(actions) == self.n_actors
         ), "The number of actions must be equal to the number of parallel environments.\
-            \nReceived {} actions for {} environments. ".format(
+            
+Received {} actions for {} environments. ".format(
             len(actions), self.n_actors
         )

--- a/helx/environment/distributed.py
+++ b/helx/environment/distributed.py
@@ -176,7 +176,6 @@ class MultiprocessEnv(Environment):
         assert (
             len(actions) == self.n_actors
         ), "The number of actions must be equal to the number of parallel environments.\
-            
-Received {} actions for {} environments. ".format(
+            \nReceived {} actions for {} environments. ".format(
             len(actions), self.n_actors
         )

--- a/helx/environment/dm_control.py
+++ b/helx/environment/dm_control.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from typing import Any
 from .base import Environment
 

--- a/helx/environment/dm_env.py
+++ b/helx/environment/dm_env.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import dm_env

--- a/helx/environment/gym.py
+++ b/helx/environment/gym.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import re

--- a/helx/environment/gym3.py
+++ b/helx/environment/gym3.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from typing import cast

--- a/helx/environment/gymnasium.py
+++ b/helx/environment/gymnasium.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import gymnasium

--- a/helx/environment/gymnax.py
+++ b/helx/environment/gymnax.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from typing import Any
 from .base import Environment
 

--- a/helx/environment/interop.py
+++ b/helx/environment/interop.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from typing import Any
 
 import bsuite.environments

--- a/helx/environment/ivy_gym.py
+++ b/helx/environment/ivy_gym.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from typing import Any
 from .base import Environment
 

--- a/helx/experiment.py
+++ b/helx/experiment.py
@@ -82,7 +82,7 @@ def run(
     )
 
     logging.info(
-"Starting experiment {}.\nThe scheduled number of episode is {}".format(
+        "Starting experiment {}.\nThe scheduled number of episode is {}".format(
             run_name, num_episodes
         )
     )

--- a/helx/experiment.py
+++ b/helx/experiment.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 from pprint import pformat
 
@@ -67,7 +82,8 @@ def run(
     )
 
     logging.info(
-        "Starting experiment {}.\nThe scheduled number of episode is {}".format(
+        "Starting experiment {}.
+The scheduled number of episode is {}".format(
             run_name, num_episodes
         )
     )

--- a/helx/experiment.py
+++ b/helx/experiment.py
@@ -82,8 +82,7 @@ def run(
     )
 
     logging.info(
-        "Starting experiment {}.
-The scheduled number of episode is {}".format(
+"Starting experiment {}.\nThe scheduled number of episode is {}".format(
             run_name, num_episodes
         )
     )

--- a/helx/flags.py
+++ b/helx/flags.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import dataclasses
 from typing import Sequence, get_type_hints
 

--- a/helx/image.py
+++ b/helx/image.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 import jax
 import jax.numpy as jnp

--- a/helx/interop.py
+++ b/helx/interop.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # pyright: reportGeneralTypeIssues=false
 from functools import singledispatch
 from typing import Any, Callable, cast

--- a/helx/logging.py
+++ b/helx/logging.py
@@ -15,6 +15,26 @@
 
 import logging
 
+BLACK = "\033[0;30m"
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+BROWN = "\033[0;33m"
+BLUE = "\033[0;34m"
+PURPLE = "\033[0;35m"
+CYAN = "\033[0;36m"
+GREY = "\033[0;37m"
+
+DARK_GREY = "\033[1;30m"
+LIGHT_RED = "\033[1;31m"
+LIGHT_GREEN = "\033[1;32m"
+YELLOW = "\033[1;33m"
+LIGHT_BLUE = "\033[1;34m"
+LIGHT_PURPLE = "\033[1;35m"
+LIGHT_CYAN = "\033[1;36m"
+WHITE = "\033[1;37m"
+RESET = "\033[0m"
+BOLD_RED = "\033[31;1m"
+
 
 _logger = None
 
@@ -42,19 +62,14 @@ def get_logger():
 
 class CustomFormatter(logging.Formatter):
 
-    grey = "[38;20m"
-    yellow = "[33;20m"
-    red = "[31;20m"
-    bold_red = "[31;1m"
-    reset = "[0m"
     format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"  # pyright: ignore reportGeneralTypeIssues
 
     FORMATS = {
-        logging.DEBUG: grey + str(format) + reset,
-        logging.INFO: grey + str(format) + reset,
-        logging.WARNING: yellow + str(format) + reset,
-        logging.ERROR: red + str(format) + reset,
-        logging.CRITICAL: bold_red + str(format) + reset,
+        logging.DEBUG: GREY + str(format) + RESET,
+        logging.INFO: GREY + str(format) + RESET,
+        logging.WARNING: YELLOW + str(format) + RESET,
+        logging.ERROR: RED + str(format) + RESET,
+        logging.CRITICAL: BOLD_RED + str(format) + RESET,
     }
 
     def format(self, record):
@@ -66,39 +81,19 @@ class CustomFormatter(logging.Formatter):
 class ColoredFormatter(logging.Formatter):
     """Special custom formatter for colorizing log messages!"""
 
-    BLACK = "[0;30m"
-    RED = "[0;31m"
-    GREEN = "[0;32m"
-    BROWN = "[0;33m"
-    BLUE = "[0;34m"
-    PURPLE = "[0;35m"
-    CYAN = "[0;36m"
-    GREY = "[0;37m"
-
-    DARK_GREY = "[1;30m"
-    LIGHT_RED = "[1;31m"
-    LIGHT_GREEN = "[1;32m"
-    YELLOW = "[1;33m"
-    LIGHT_BLUE = "[1;34m"
-    LIGHT_PURPLE = "[1;35m"
-    LIGHT_CYAN = "[1;36m"
-    WHITE = "[1;37m"
-
-    RESET = "[0m"
-
     def __init__(self, *args, **kwargs):
         self._colors = {
-            logging.DEBUG: self.DARK_GREY,
-            logging.INFO: self.RESET,
-            logging.WARNING: self.BROWN,
-            logging.ERROR: self.RED,
-            logging.CRITICAL: self.LIGHT_RED,
+            logging.DEBUG: DARK_GREY,
+            logging.INFO: RESET,
+            logging.WARNING: BROWN,
+            logging.ERROR: RED,
+            logging.CRITICAL: LIGHT_RED,
         }
         super(ColoredFormatter, self).__init__(*args, **kwargs)
 
     def format(self, record):
         """Applies the color formats"""
-        record.msg = self._colors[record.levelno] + record.msg + self.RESET
+        record.msg = self._colors[record.levelno] + record.msg + RESET
         return logging.Formatter.format(self, record)
 
     def setLevelColor(self, logging_level, escaped_ansi_code):
@@ -107,25 +102,24 @@ class ColoredFormatter(logging.Formatter):
 
 class ColorizingStreamHandler(logging.StreamHandler):
 
-    BLACK = "[0;30m"
-    RED = "[0;31m"
-    GREEN = "[0;32m"
-    BROWN = "[0;33m"
-    BLUE = "[0;34m"
-    PURPLE = "[0;35m"
-    CYAN = "[0;36m"
-    GREY = "[0;37m"
+    BLACK = "\033[0;30m"
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    BROWN = "\033[0;33m"
+    BLUE = "\033[0;34m"
+    PURPLE = "\033[0;35m"
+    CYAN = "\033[0;36m"
+    GREY = "\033[0;37m"
 
-    DARK_GREY = "[1;30m"
-    LIGHT_RED = "[1;31m"
-    LIGHT_GREEN = "[1;32m"
-    YELLOW = "[1;33m"
-    LIGHT_BLUE = "[1;34m"
-    LIGHT_PURPLE = "[1;35m"
-    LIGHT_CYAN = "[1;36m"
-    WHITE = "[1;37m"
-
-    RESET = "[0m"
+    DARK_GREY = "\033[1;30m"
+    LIGHT_RED = "\033[1;31m"
+    LIGHT_GREEN = "\033[1;32m"
+    YELLOW = "\033[1;33m"
+    LIGHT_BLUE = "\033[1;34m"
+    LIGHT_PURPLE = "\033[1;35m"
+    LIGHT_CYAN = "\033[1;36m"
+    WHITE = "\033[1;37m"
+    RESET = "\033[0m"
 
     def __init__(self, *args, **kwargs):
         self._colors = {
@@ -151,8 +145,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
             else:
                 message = self._colors[record.levelno] + message + self.RESET
                 stream.write(message)
-            stream.write(getattr(self, "terminator", "
-"))
+            stream.write(getattr(self, "terminator", "\n"))
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/helx/logging.py
+++ b/helx/logging.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 
@@ -27,11 +42,11 @@ def get_logger():
 
 class CustomFormatter(logging.Formatter):
 
-    grey = "\x1b[38;20m"
-    yellow = "\x1b[33;20m"
-    red = "\x1b[31;20m"
-    bold_red = "\x1b[31;1m"
-    reset = "\x1b[0m"
+    grey = "[38;20m"
+    yellow = "[33;20m"
+    red = "[31;20m"
+    bold_red = "[31;1m"
+    reset = "[0m"
     format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"  # pyright: ignore reportGeneralTypeIssues
 
     FORMATS = {
@@ -51,25 +66,25 @@ class CustomFormatter(logging.Formatter):
 class ColoredFormatter(logging.Formatter):
     """Special custom formatter for colorizing log messages!"""
 
-    BLACK = "\033[0;30m"
-    RED = "\033[0;31m"
-    GREEN = "\033[0;32m"
-    BROWN = "\033[0;33m"
-    BLUE = "\033[0;34m"
-    PURPLE = "\033[0;35m"
-    CYAN = "\033[0;36m"
-    GREY = "\033[0;37m"
+    BLACK = "[0;30m"
+    RED = "[0;31m"
+    GREEN = "[0;32m"
+    BROWN = "[0;33m"
+    BLUE = "[0;34m"
+    PURPLE = "[0;35m"
+    CYAN = "[0;36m"
+    GREY = "[0;37m"
 
-    DARK_GREY = "\033[1;30m"
-    LIGHT_RED = "\033[1;31m"
-    LIGHT_GREEN = "\033[1;32m"
-    YELLOW = "\033[1;33m"
-    LIGHT_BLUE = "\033[1;34m"
-    LIGHT_PURPLE = "\033[1;35m"
-    LIGHT_CYAN = "\033[1;36m"
-    WHITE = "\033[1;37m"
+    DARK_GREY = "[1;30m"
+    LIGHT_RED = "[1;31m"
+    LIGHT_GREEN = "[1;32m"
+    YELLOW = "[1;33m"
+    LIGHT_BLUE = "[1;34m"
+    LIGHT_PURPLE = "[1;35m"
+    LIGHT_CYAN = "[1;36m"
+    WHITE = "[1;37m"
 
-    RESET = "\033[0m"
+    RESET = "[0m"
 
     def __init__(self, *args, **kwargs):
         self._colors = {
@@ -92,25 +107,25 @@ class ColoredFormatter(logging.Formatter):
 
 class ColorizingStreamHandler(logging.StreamHandler):
 
-    BLACK = "\033[0;30m"
-    RED = "\033[0;31m"
-    GREEN = "\033[0;32m"
-    BROWN = "\033[0;33m"
-    BLUE = "\033[0;34m"
-    PURPLE = "\033[0;35m"
-    CYAN = "\033[0;36m"
-    GREY = "\033[0;37m"
+    BLACK = "[0;30m"
+    RED = "[0;31m"
+    GREEN = "[0;32m"
+    BROWN = "[0;33m"
+    BLUE = "[0;34m"
+    PURPLE = "[0;35m"
+    CYAN = "[0;36m"
+    GREY = "[0;37m"
 
-    DARK_GREY = "\033[1;30m"
-    LIGHT_RED = "\033[1;31m"
-    LIGHT_GREEN = "\033[1;32m"
-    YELLOW = "\033[1;33m"
-    LIGHT_BLUE = "\033[1;34m"
-    LIGHT_PURPLE = "\033[1;35m"
-    LIGHT_CYAN = "\033[1;36m"
-    WHITE = "\033[1;37m"
+    DARK_GREY = "[1;30m"
+    LIGHT_RED = "[1;31m"
+    LIGHT_GREEN = "[1;32m"
+    YELLOW = "[1;33m"
+    LIGHT_BLUE = "[1;34m"
+    LIGHT_PURPLE = "[1;35m"
+    LIGHT_CYAN = "[1;36m"
+    WHITE = "[1;37m"
 
-    RESET = "\033[0m"
+    RESET = "[0m"
 
     def __init__(self, *args, **kwargs):
         self._colors = {
@@ -136,7 +151,8 @@ class ColorizingStreamHandler(logging.StreamHandler):
             else:
                 message = self._colors[record.levelno] + message + self.RESET
                 stream.write(message)
-            stream.write(getattr(self, "terminator", "\n"))
+            stream.write(getattr(self, "terminator", "
+"))
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/helx/logging.py
+++ b/helx/logging.py
@@ -101,33 +101,13 @@ class ColoredFormatter(logging.Formatter):
 
 
 class ColorizingStreamHandler(logging.StreamHandler):
-
-    BLACK = "\033[0;30m"
-    RED = "\033[0;31m"
-    GREEN = "\033[0;32m"
-    BROWN = "\033[0;33m"
-    BLUE = "\033[0;34m"
-    PURPLE = "\033[0;35m"
-    CYAN = "\033[0;36m"
-    GREY = "\033[0;37m"
-
-    DARK_GREY = "\033[1;30m"
-    LIGHT_RED = "\033[1;31m"
-    LIGHT_GREEN = "\033[1;32m"
-    YELLOW = "\033[1;33m"
-    LIGHT_BLUE = "\033[1;34m"
-    LIGHT_PURPLE = "\033[1;35m"
-    LIGHT_CYAN = "\033[1;36m"
-    WHITE = "\033[1;37m"
-    RESET = "\033[0m"
-
     def __init__(self, *args, **kwargs):
         self._colors = {
-            logging.DEBUG: self.DARK_GREY,
-            logging.INFO: self.RESET,
-            logging.WARNING: self.BROWN,
-            logging.ERROR: self.RED,
-            logging.CRITICAL: self.LIGHT_RED,
+            logging.DEBUG: DARK_GREY,
+            logging.INFO: RESET,
+            logging.WARNING: BROWN,
+            logging.ERROR: RED,
+            logging.CRITICAL: LIGHT_RED,
         }
         super(ColorizingStreamHandler, self).__init__(*args, **kwargs)
 
@@ -143,7 +123,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
             if not self.is_tty:
                 stream.write(message)
             else:
-                message = self._colors[record.levelno] + message + self.RESET
+                message = self._colors[record.levelno] + message + RESET
                 stream.write(message)
             stream.write(getattr(self, "terminator", "\n"))
             self.flush()

--- a/helx/mdp.py
+++ b/helx/mdp.py
@@ -115,7 +115,7 @@ class Episode:
         >>> $d_1, d_2, d_3, ..., d_t$
     ```
     And corresponds to the following sarsa unroll:
-    $\langle s_0, a_0, r_1, s_1, d_1, a_1 \rangle$
+    $\\langle s_0, a_0, r_1, s_1, d_1, a_1 \\rangle$
 
     Where, $a_0$ corresponds to the action taken with respect to
     observation $s_0$, and $r_1$ is the reward received during the transition

--- a/helx/mdp.py
+++ b/helx/mdp.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from enum import IntEnum
@@ -100,7 +115,7 @@ class Episode:
         >>> $d_1, d_2, d_3, ..., d_t$
     ```
     And corresponds to the following sarsa unroll:
-    $\\langle s_0, a_0, r_1, s_1, d_1, a_1 \\rangle$
+    $\langle s_0, a_0, r_1, s_1, d_1, a_1 \rangle$
 
     Where, $a_0$ corresponds to the action taken with respect to
     observation $s_0$, and $r_1$ is the reward received during the transition

--- a/helx/memory.py
+++ b/helx/memory.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from typing import Generic, List, Sequence, TypeVar, Deque

--- a/helx/networks/__init__.py
+++ b/helx/networks/__init__.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from .actors import Actor, EGreedyPolicy, GaussianPolicy, SoftmaxPolicy
 from .architectures import AgentNetwork
 from .critics import Critic, DoubleQCritic

--- a/helx/networks/actors.py
+++ b/helx/networks/actors.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import operator

--- a/helx/networks/architectures.py
+++ b/helx/networks/architectures.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from typing import Any, Tuple, Dict
@@ -90,7 +105,7 @@ class AgentNetwork(nn.Module):
     def actor(
         self, params: nn.FrozenDict, observation: Array, key: KeyArray
     ) -> Tuple[Action, Array]:
-        """The actor function to evaluate the agent's policy $\\pi(s)$.
+        """The actor function to evaluate the agent's policy $\pi(s)$.
         Args:
             params (nn.FrozenDict): The agent's parameters.
             observation (Array): The environment observation.
@@ -115,7 +130,7 @@ class AgentNetwork(nn.Module):
         self, params: nn.FrozenDict, observation: Array, *args, **kwargs
     ) -> Array | PyTreeDef:
         """The critic function to evaluate the agent's value function
-        $V(s)$ or $Q(s) \\forall a in \\mathcal{A}
+        $V(s)$ or $Q(s) \forall a in \mathcal{A}
         Args:
             params (nn.FrozenDict): The agent's parameters.
             observation (Array): The environment observation.

--- a/helx/networks/architectures.py
+++ b/helx/networks/architectures.py
@@ -105,7 +105,7 @@ class AgentNetwork(nn.Module):
     def actor(
         self, params: nn.FrozenDict, observation: Array, key: KeyArray
     ) -> Tuple[Action, Array]:
-        """The actor function to evaluate the agent's policy $\pi(s)$.
+        """The actor function to evaluate the agent's policy $\\pi(s)$.
         Args:
             params (nn.FrozenDict): The agent's parameters.
             observation (Array): The environment observation.
@@ -130,7 +130,7 @@ class AgentNetwork(nn.Module):
         self, params: nn.FrozenDict, observation: Array, *args, **kwargs
     ) -> Array | PyTreeDef:
         """The critic function to evaluate the agent's value function
-        $V(s)$ or $Q(s) \forall a in \mathcal{A}
+        $V(s)$ or $Q(s) \\forall a in \\mathcal{A}
         Args:
             params (nn.FrozenDict): The agent's parameters.
             observation (Array): The environment observation.

--- a/helx/networks/critics.py
+++ b/helx/networks/critics.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 from typing import Tuple

--- a/helx/networks/modules.py
+++ b/helx/networks/modules.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import copy

--- a/helx/preprocess.py
+++ b/helx/preprocess.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import jax
 import jax.numpy as jnp
 from chex import Shape

--- a/helx/random.py
+++ b/helx/random.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Random number generation utilities."""
 from typing import Generator
 import jax

--- a/helx/spaces.py
+++ b/helx/spaces.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import abc

--- a/helx/stax.py
+++ b/helx/stax.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Common missing modules to the jax.stax library"""
 from typing import NamedTuple
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 import os
 import platform
@@ -14,9 +29,9 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_PATH = "requirements.txt"
 MUJOCO_ROOT = os.path.join(os.path.expanduser("~"), ".mujoco")
 ATARI_ROOT = os.path.join(os.path.expanduser("~"), ".atari")
-BOLD = "\033[1m"
-DARK_GREY = "\033[1;30m"
-END = "\033[0m"
+BOLD = "[1m"
+DARK_GREY = "[1;30m"
+END = "[0m"
 
 
 logger = logging.getLogger("helx setup")
@@ -185,7 +200,8 @@ def _get_version():
     with open(filepath) as f:
         for line in f:
             if line.startswith("__version__") and "=" in line:
-                version = line[line.find("=") + 1 :].strip(" '\"\n")
+                version = line[line.find("=") + 1 :].strip(" '\"
+")
                 if version:
                     return version
     raise ValueError("`__version__` not defined in {}".format(filepath))

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_PATH = "requirements.txt"
 MUJOCO_ROOT = os.path.join(os.path.expanduser("~"), ".mujoco")
 ATARI_ROOT = os.path.join(os.path.expanduser("~"), ".atari")
-BOLD = "[1m"
-DARK_GREY = "[1;30m"
-END = "[0m"
+BOLD = "\033[1m"
+DARK_GREY = "\033[1;30m"
+END = "\033[0m"
 
 
 logger = logging.getLogger("helx setup")
@@ -200,8 +200,7 @@ def _get_version():
     with open(filepath) as f:
         for line in f:
             if line.startswith("__version__") and "=" in line:
-                version = line[line.find("=") + 1 :].strip(" '\"
-")
+                version = line[line.find("=") + 1 :].strip(" '\"\n")
                 if version:
                     return version
     raise ValueError("`__version__` not defined in {}".format(filepath))

--- a/test/test_atari.py
+++ b/test/test_atari.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 import gym

--- a/test/test_bsuite.py
+++ b/test/test_bsuite.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 import bsuite

--- a/test/test_dm_control.py
+++ b/test/test_dm_control.py
@@ -1,0 +1,13 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/test_flags.py
+++ b/test/test_flags.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 import jax.numpy as jnp

--- a/test/test_gym3_procgen.py
+++ b/test/test_gym3_procgen.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 import gym

--- a/test/test_gym_minigrid.py
+++ b/test/test_gym_minigrid.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 import gym

--- a/test/test_gym_mujoco.py
+++ b/test/test_gym_mujoco.py
@@ -1,3 +1,18 @@
+# Copyright [2023] The Helx Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 
 import gym


### PR DESCRIPTION
Closes #26 

- Add `NOTICE` files following https://www.apache.org/licenses/LICENSE-2.0
- Add boilerplate `COOPYRIGHT` in root
- Add copyright information in the `LICENSE` file
- Add header to all python files